### PR TITLE
🔒 Fix Arbitrary File Write in MemoryTransferManager.export_to_tar

### DIFF
--- a/src/ledgermind/core/api/transfer.py
+++ b/src/ledgermind/core/api/transfer.py
@@ -14,7 +14,17 @@ class MemoryTransferManager:
         self.storage_path = storage_path
 
     def export_to_tar(self, output_path: str) -> str:
-        """Packs the entire memory storage into a .tar.gz archive."""
+        """Packs the entire memory storage into a .tar.gz archive.
+
+        Args:
+            output_path: The filename for the export. Must not contain directory path components.
+
+        Raises:
+            ValueError: If output_path contains directory components (security check).
+        """
+        if os.path.basename(output_path) != output_path:
+            raise ValueError(f"Security violation: Export path '{output_path}' must be a filename, not a path.")
+
         if not output_path.endswith(".tar.gz"):
             output_path += ".tar.gz"
             

--- a/tests/core/audit/test_transfer.py
+++ b/tests/core/audit/test_transfer.py
@@ -11,20 +11,39 @@ def test_export_import_tar(tmp_path):
     (source_dir / "data.txt").write_text("hello world")
     
     manager = MemoryTransferManager(str(source_dir))
-    tar_path = str(tmp_path / "backup.tar.gz")
+    tar_path = "backup.tar.gz"
     
     # Export
-    exported = manager.export_to_tar(tar_path)
-    assert os.path.exists(exported)
-    assert exported.endswith(".tar.gz")
-    
-    # Import
-    restore_dir = tmp_path / "restore"
-    restore_dir.mkdir()
-    manager.import_from_tar(exported, str(restore_dir / "source"))
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        exported = manager.export_to_tar(tar_path)
+        assert os.path.exists(exported)
+        assert exported.endswith(".tar.gz")
+
+        # Import
+        restore_dir = tmp_path / "restore"
+        restore_dir.mkdir()
+        manager.import_from_tar(exported, str(restore_dir / "source"))
+    finally:
+        os.chdir(cwd)
     
     # Verify (shutil.extractall puts it in a subdir usually)
     restored_file = restore_dir / "source" / "data.txt"
     assert restored_file.exists()
     assert restored_file.read_text() == "hello world"
 
+def test_export_security_violation(tmp_path):
+    manager = MemoryTransferManager(str(tmp_path))
+
+    # Test absolute path
+    with pytest.raises(ValueError, match="Security violation"):
+        manager.export_to_tar("/tmp/unsafe.tar.gz")
+
+    # Test directory traversal
+    with pytest.raises(ValueError, match="Security violation"):
+        manager.export_to_tar("../unsafe.tar.gz")
+
+    # Test subdirectory
+    with pytest.raises(ValueError, match="Security violation"):
+        manager.export_to_tar("subdir/unsafe.tar.gz")


### PR DESCRIPTION
Fixed an arbitrary file write vulnerability in `src/ledgermind/core/api/transfer.py` where `MemoryTransferManager.export_to_tar` accepted unsanitized paths. 

The fix enforces that `output_path` must be a filename without directory components, raising a `ValueError` otherwise. This prevents directory traversal and arbitrary file write attacks.

Existing tests in `tests/core/audit/test_transfer.py` were updated to accommodate this change (by changing CWD during the test), and new test cases were added to verify that unsafe paths are rejected.

---
*PR created automatically by Jules for task [7447055770191676515](https://jules.google.com/task/7447055770191676515) started by @sl4m3*