### PR TITLE
test(core): add tests for DistillationEngine trajectories

### DIFF
--- a/tests/core/test_distillation.py
+++ b/tests/core/test_distillation.py
@@ -1,0 +1,135 @@
+import pytest
+import os
+import json
+from datetime import datetime
+from ledgermind.core.reasoning.distillation import DistillationEngine
+from ledgermind.core.stores.episodic import EpisodicStore
+from ledgermind.core.core.schemas import MemoryEvent, KIND_RESULT, ProceduralContent, ProposalContent
+
+@pytest.fixture
+def temp_db_path(tmp_path):
+    db_file = tmp_path / "test_episodic.db"
+    return str(db_file)
+
+@pytest.fixture
+def episodic_store(temp_db_path):
+    store = EpisodicStore(temp_db_path)
+    return store
+
+@pytest.fixture
+def distillation_engine(episodic_store):
+    return DistillationEngine(episodic_store, window_size=5)
+
+def create_event(store, kind, content, context=None, source="agent"):
+    event = MemoryEvent(
+        source=source,
+        kind=kind,
+        content=content,
+        context=context or {},
+        timestamp=datetime.now()
+    )
+    return store.append(event)
+
+def test_distill_basic_flow(episodic_store, distillation_engine):
+    """Test basic distillation of a successful trajectory."""
+    # 1. Add a successful sequence
+    create_event(episodic_store, "task", "Solve the puzzle")
+    create_event(episodic_store, "prompt", "Thinking about move")
+    create_event(episodic_store, "call", "tool_call_move(x=1)")
+
+    # Result event with success context
+    result_context = {"success": True, "target": "Solve the puzzle"}
+    result_id = create_event(episodic_store, KIND_RESULT, "Puzzle solved", result_context)
+
+    # 2. Distill
+    proposals = distillation_engine.distill_trajectories()
+
+    # 3. Verify
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.target == "Solve the puzzle"
+    assert len(proposal.procedural.steps) == 3
+    # Check steps content (action includes kind and content)
+    assert "TASK" in proposal.procedural.steps[0].action
+    assert "Solve the puzzle" in proposal.procedural.steps[0].action
+    assert "PROMPT" in proposal.procedural.steps[1].action
+    assert "Thinking about move" in proposal.procedural.steps[1].action
+    assert "CALL" in proposal.procedural.steps[2].action
+    assert "tool_call_move" in proposal.procedural.steps[2].action
+
+    assert result_id in proposal.evidence_event_ids
+
+def test_distill_with_after_id(episodic_store, distillation_engine):
+    """Test distillation with after_id parameter."""
+    # Add some events that should be ignored if we use after_id
+    id1 = create_event(episodic_store, "task", "Old task")
+    id2 = create_event(episodic_store, KIND_RESULT, "Old result", {"success": True})
+
+    # New sequence
+    id3 = create_event(episodic_store, "task", "New task")
+    id4 = create_event(episodic_store, KIND_RESULT, "New result", {"success": True, "target": "New task"})
+
+    # Distill after id2
+    proposals = distillation_engine.distill_trajectories(after_id=id2)
+
+    assert len(proposals) == 1
+    assert proposals[0].target == "New task"
+    # Steps should include "New task"
+    assert len(proposals[0].procedural.steps) == 1
+    assert "New task" in proposals[0].procedural.steps[0].action
+
+def test_distill_boundary_first_event_is_result(episodic_store, distillation_engine):
+    """Test boundary condition where the very first event is a result."""
+    # If the very first event is a result, trajectory is empty.
+    create_event(episodic_store, KIND_RESULT, "Immediate success", {"success": True, "target": "Zero work"})
+
+    proposals = distillation_engine.distill_trajectories()
+
+    # trajectory_events = chronological_events[max(0, i - self.window_size):i]
+    # If i=0, slice is 0:0 -> empty.
+    # if trajectory_events: ... -> False
+    assert len(proposals) == 0
+
+def test_distill_failure_ignored(episodic_store, distillation_engine):
+    """Test that failed results do not generate proposals."""
+    create_event(episodic_store, "task", "Hard task")
+    create_event(episodic_store, KIND_RESULT, "Failed attempt", {"success": False, "target": "Hard task"})
+
+    proposals = distillation_engine.distill_trajectories()
+    assert len(proposals) == 0
+
+def test_distill_window_limit(episodic_store, distillation_engine):
+    """Test that the window size limits the number of steps in a proposal."""
+    # Window size is 5 (from fixture)
+    # Add 7 events before result
+    for i in range(7):
+        create_event(episodic_store, "task", f"Step {i}")
+
+    create_event(episodic_store, KIND_RESULT, "Success", {"success": True, "target": "Long task"})
+
+    proposals = distillation_engine.distill_trajectories()
+    assert len(proposals) == 1
+    # Should only have last 5 steps
+    steps = proposals[0].procedural.steps
+    assert len(steps) == 5
+    # Steps 0 and 1 are skipped. 2,3,4,5,6 are kept.
+    assert "Step 2" in steps[0].action
+    assert "Step 6" in steps[4].action
+
+def test_distill_multiple_trajectories(episodic_store, distillation_engine):
+    """Test finding multiple trajectories in the event stream."""
+    # Trajectory 1
+    create_event(episodic_store, "task", "Task 1")
+    create_event(episodic_store, KIND_RESULT, "Result 1", {"success": True, "target": "Task 1"})
+
+    # Trajectory 2
+    create_event(episodic_store, "task", "Task 2")
+    create_event(episodic_store, KIND_RESULT, "Result 2", {"success": True, "target": "Task 2"})
+
+    proposals = distillation_engine.distill_trajectories()
+
+    # Should find both
+    assert len(proposals) == 2
+    targets = {p.target for p in proposals}
+    assert "Task 1" in targets
+    assert "Task 2" in targets


### PR DESCRIPTION
Implemented comprehensive tests for `DistillationEngine.distill_trajectories` to ensure reliability and correct handling of event streams, edge cases, and pagination. Validated with `pytest`.

---
*PR created automatically by Jules for task [18070708764261676764](https://jules.google.com/task/18070708764261676764) started by @sl4m3*