### PR TITLE
feat(security): prevent symlink traversal in project scanner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-26 - [Scanner Symlink Traversal]
+**Vulnerability:** ProjectScanner followed symlinks, allowing read access to files outside the project root if a malicious symlink was present.
+**Learning:** File enumeration tools must explicitly handle or ignore symlinks to prevent unintentional path traversal and information disclosure.
+**Prevention:** always check `os.path.islink()` before opening files in scanner/backup tools and skip them unless explicitly required and validated.

--- a/src/ledgermind/server/tools/scanner.py
+++ b/src/ledgermind/server/tools/scanner.py
@@ -117,6 +117,11 @@ class ProjectScanner:
                     # Match target files or any .md file (documentation)
                     if f in self.target_files or f.lower().endswith('.md'):
                         file_path = os.path.join(root, f)
+
+                        # Security: Do not follow symlinks to avoid path traversal
+                        if os.path.islink(file_path):
+                            continue
+
                         rel_file_path = os.path.relpath(file_path, self.root_path)
                         
                         try:


### PR DESCRIPTION
Sentinel identified a potential path traversal vulnerability in `ProjectScanner` where symbolic links could be used to read files outside the intended project directory.

This change adds an explicit check `if os.path.islink(file_path): continue` to the file scanning loop, ensuring that symlinks are ignored and only regular files within the project root are processed. This aligns with the security requirement to prevent information disclosure.

Verified with a targeted test case (`tests/security/test_scanner_symlink.py`, which was created, passed, and then cleaned up).

---
*PR created automatically by Jules for task [13749120827252809508](https://jules.google.com/task/13749120827252809508) started by @sl4m3*