### PR TITLE
⚡ Bolt: [Performance Improvement] Memoize lifecycle weight calculation in search queries

### DIFF
--- a/src/ledgermind/core/api/services/query.py
+++ b/src/ledgermind/core/api/services/query.py
@@ -77,17 +77,30 @@ class QueryService(MemoryService):
         meta_cache = {m['fid']: m for m in self.semantic.meta.get_batch_by_fids(all_initial_fids)}
 
         scores = {}
+        # ⚡ Bolt: Memoize weight calculation dynamically to avoid redundant function calls and dictionary lookups
+        weight_cache = {}
+
         for rank, item in enumerate(vec_results):
             fid = item['id']
-            meta = meta_cache.get(fid)
-            weight = self._get_lifecycle_weight(meta)
-            scores[fid] = scores.get(fid, 0.0) + (weight / (k + rank + 1))
+            if fid not in weight_cache:
+                weight_cache[fid] = self._get_lifecycle_weight(meta_cache.get(fid))
+
+            weight = weight_cache[fid]
+            if fid in scores:
+                scores[fid] += (weight / (k + rank + 1))
+            else:
+                scores[fid] = (weight / (k + rank + 1))
             
         for rank, r in enumerate(kw_results):
             fid = r['fid']
-            meta = meta_cache.get(fid)
-            weight = self._get_lifecycle_weight(meta)
-            scores[fid] = scores.get(fid, 0.0) + (weight / (k + rank + 1))
+            if fid not in weight_cache:
+                weight_cache[fid] = self._get_lifecycle_weight(meta_cache.get(fid))
+
+            weight = weight_cache[fid]
+            if fid in scores:
+                scores[fid] += (weight / (k + rank + 1))
+            else:
+                scores[fid] = (weight / (k + rank + 1))
 
         max_rrf = 3.0 / (k + 1.0)
         sorted_fids = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)


### PR DESCRIPTION
💡 What:
Introduced a `weight_cache` to memoize the results of `self._get_lifecycle_weight(meta)` in the `search` method of `src/ledgermind/core/api/services/query.py`. Also replaced `scores.get(fid, 0.0) + ...` with a faster `if fid in scores:` check to avoid the overhead of Python's `dict.get` in the hot loop.

🎯 Why:
During Reciprocal Rank Fusion (RRF), the system processes overlapping document IDs from both vector and keyword search results. The original code repeatedly executed dictionary lookups for `meta_cache` and recalculated lifecycle weights (involving `.lower()` string operations and multiple `.get()` dictionary operations inside `_get_lifecycle_weight`) for the exact same `fid`. This change eliminates the redundant calculations.

📊 Impact:
Reduces CPU overhead during the RRF result processing loop by cutting function call and dictionary lookup times roughly in half for duplicated `fid` hits.

🔬 Measurement:
Run queries using vector and keyword models and measure overall search latency and CPU usage during RRF execution.

---
*PR created automatically by Jules for task [17901761231417339182](https://jules.google.com/task/17901761231417339182) started by @sl4m3*