### PR TITLE
🎨 Palette: [UX improvement] Improve error state visibility and dismissal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-24 - Missing accessibility states for background tasks
 **Learning:** In VS Code extensions, background watchers that execute silently can fail or hang without the user knowing. This breaks accessibility guidelines as screen readers and visual indicators do not alert the user to ongoing work or failures.
 **Action:** Always wrap async or background processes (like `execFile`) with loading state handlers (e.g., `setBusy(true/false)`) and ensure error callbacks explicitly set error UI states (e.g., `setError(true)`) to provide consistent, accessible feedback via status bar items or ARIA labels.
+## 2024-04-16 - Accessible Error State Management
+**Learning:** Background process errors (like file watcher JSON parsing) need accessible visual cues via the status bar, and users need an interactive path to dismiss these error states (e.g. by clicking to open logs).
+**Action:** Always wrap background processes with accessible error state triggers (`setError(true)`) and ensure the associated UI element's command can clear the error state.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -22,9 +22,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(outputChannel);
 
     const showOutputCommandId = 'ledgermind.showOutput';
-    context.subscriptions.push(vscode.commands.registerCommand(showOutputCommandId, () => {
-        outputChannel.show();
-    }));
     statusBarItem.command = showOutputCommandId;
 
     let isBusy = false;
@@ -54,6 +51,11 @@ export function activate(context: vscode.ExtensionContext) {
         isBusy = busy;
         setError(false);
     };
+
+    context.subscriptions.push(vscode.commands.registerCommand(showOutputCommandId, () => {
+        outputChannel.show();
+        setError(false); // Clear error state when logs are opened
+    }));
 
     // ==========================================
     // DUAL-HOOK MECHANISM (Cache + onDidReceiveChatResponse)
@@ -277,6 +279,7 @@ ${stdout}`;
                     }
                 } catch (err) {
                     outputChannel.appendLine(`LedgerMind File Watcher Error: ${(err as Error).message}`);
+                    setError(true);
                 }
             }, 2000); // Debounce 2s
         });


### PR DESCRIPTION
## 💡 What
Modified `src/ledgermind/vscode/src/extension.ts` to improve the error state feedback of the VS Code extension's status bar item. The `showOutputCommandId` registration was moved below the `setError` definition, allowing the callback to invoke `setError(false)`. Also, background file watcher JSON parsing failures now explicitly trigger the visual error state. Finally, recorded a critical UX learning in `.jules/palette.md`.

## 🎯 Why
Background process errors (like the JSON parsing of file watcher events) need accessible visual cues to prevent silent failures. Moreover, users need an interactive and intuitive path to clear error states; otherwise, the status bar can remain "stuck" showing an error, degrading the user experience. Now, simply clicking the error to view the logs naturally clears the visual error indicator.

## 📸 Before/After
**Before:** File watcher parsing errors were swallowed silently in the output logs. The status bar error state (when triggered elsewhere) could not be intuitively cleared by interacting with it.
**After:** File watcher parsing failures update the status bar with an explicit error icon. Clicking the status bar item to open the logs immediately clears the error state and resets the UI back to normal.

## ♿ Accessibility
The status bar error state relies on accessibility information (ARIA roles and labels). Ensuring that the visual error state properly synchronizes with user interactions prevents screen readers from persistently announcing outdated error statuses.

---
*PR created automatically by Jules for task [3553978606014335036](https://jules.google.com/task/3553978606014335036) started by @sl4m3*