### PR TITLE
⚡ Bolt: Replace lambda functions with C-optimized accessors for faster sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2025-04-16 - [O(N) Max and Sorting Optimizations]
 **Learning:** In tight loops evaluating dict scores (like `trajectory.py` recovering paths), using `sorted(d.items(), key=lambda x: x[1])[0][0]` runs in O(N log N) and creates unnecessary temporary lists. Finding the maximum key directly using `max(d, key=d.get)` runs in O(N) and operates strictly on the dictionary iterators. Additionally, using `lambda` functions for key sorting introduces significant Python-level function call overhead.
 **Action:** Always prefer `max()`/`min()` over sorting when only the extremes are needed. Replace lambda functions in `sorted()` or `max()` with C-optimized accessors like `dict.get` or `operator.itemgetter` wherever possible.
+## 2026-04-17 - Replace lambda functions with C-optimized accessors for faster sorting
+**Learning:** In tight sorting or selection loops, using a Python `lambda` function inside `key=` arguments introduces significant function-call overhead.
+**Action:** Replace `lambda x: x['key']` with `operator.itemgetter('key')` and replace `lambda p: self.list.index(p)` with a direct method reference like `self.list.index` to leverage C-optimized implementations for measurable performance gains in tight loops.

--- a/src/ledgermind/core/api/services/query.py
+++ b/src/ledgermind/core/api/services/query.py
@@ -68,7 +68,7 @@ class QueryService(MemoryService):
                     "kind": r['kind']
                 } for r in kw_results]
                 # V7.1: MUST SORT by score, otherwise weights have no effect on order
-                return sorted(fast_results, key=lambda x: x['score'], reverse=True)
+                return sorted(fast_results, key=itemgetter('score'), reverse=True)
 
         search_limit = max(200, (offset + limit) * 10) if namespace else (offset + limit) * 3
         

--- a/src/ledgermind/core/reasoning/enrichment/facade.py
+++ b/src/ledgermind/core/reasoning/enrichment/facade.py
@@ -78,7 +78,7 @@ class LLMEnricher:
             return DecisionPhase.PATTERN
 
         # 1. Определяем максимальную фазу
-        max_phase = max(source_phases, key=lambda p: self.PHASE_ORDER.index(p))
+        max_phase = max(source_phases, key=self.PHASE_ORDER.index)
 
         # 2. Понижаем фазу если метрики не дотягивают
         for phase in reversed(self.PHASE_ORDER):  # CANONICAL → EMERGENT → PATTERN

--- a/src/ledgermind/core/stores/vector.py
+++ b/src/ledgermind/core/stores/vector.py
@@ -1,4 +1,5 @@
 import os
+from operator import itemgetter
 import time
 import numpy as np
 import logging
@@ -726,7 +727,7 @@ class VectorStore:
                 })
 
         # Merge and Sort
-        results.sort(key=lambda x: x["score"], reverse=True)
+        results.sort(key=itemgetter("score"), reverse=True)
 
         # Deduplicate by ID? No, original didn't.
 


### PR DESCRIPTION
💡 What: Replaced Python `lambda` functions used as `key` arguments in `sort()` and `max()` calls with C-optimized builtins (`operator.itemgetter` and direct method references).

🎯 Why: In tight sorting or selection loops within the query service and enrichment processor, evaluating Python lambdas introduces significant function-call overhead. Leveraging C-level accessors minimizes this latency.

📊 Impact: Expected to reduce execution time for dictionary extraction and sorting in hot paths, leading to measurably faster vector query processing and list generation.

🔬 Measurement: Run the test suite or verify metric timestamps against execution lengths when performing heavy queries that trigger `QueryService.search`.

---
*PR created automatically by Jules for task [16274717366199758629](https://jules.google.com/task/16274717366199758629) started by @sl4m3*