### PR TITLE
🎨 Palette: Fix concurrent loading states for status bar item

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - VS Code Concurrent Loading States
+**Learning:** Overlapping background operations (like file saves and chat responses) can prematurely clear loading indicators if a simple boolean flag is used for state tracking. This causes screen readers to announce incorrect idle states while work is still ongoing.
+**Action:** Always use a reference counter (`busyCount`) instead of a boolean for shared UI loading states that map to concurrent async operations.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
     const showOutputCommandId = 'ledgermind.showOutput';
     statusBarItem.command = showOutputCommandId;
 
-    let isBusy = false;
+    let busyCount = 0;
 
     const setError = (hasError: boolean) => {
         if (hasError) {
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
         } else {
             statusBarItem.backgroundColor = undefined;
-            if (isBusy) {
+            if (busyCount > 0) {
                 statusBarItem.text = '$(sync~spin) LedgerMind';
                 statusBarItem.tooltip = 'LedgerMind: Syncing Context... (Click to view logs)';
                 statusBarItem.accessibilityInformation = { label: 'LedgerMind Syncing Context, click to view logs', role: 'button' };
@@ -47,9 +47,19 @@ export function activate(context: vscode.ExtensionContext) {
     };
 
     const setBusy = (busy: boolean) => {
-        if (isBusy === busy) return;
-        isBusy = busy;
-        setError(false);
+        if (busy) {
+            busyCount++;
+            if (busyCount === 1) {
+                setError(false);
+            }
+        } else {
+            if (busyCount > 0) {
+                busyCount--;
+                if (busyCount === 0) {
+                    setError(false);
+                }
+            }
+        }
     };
 
     context.subscriptions.push(vscode.commands.registerCommand(showOutputCommandId, () => {


### PR DESCRIPTION
💡 What: Changed the VS Code status bar loading state handler to use a counter instead of a boolean.
🎯 Why: Previously, overlapping background sync operations (file saves, chat requests) would prematurely clear the loading spinner and accessibility state when the first operation finished, even if others were still running.
📸 Before/After: Visual transition from flickering spinner to stable concurrent spinner.
♿ Accessibility: Ensures screen readers receive accurate sync state representations during concurrent operations.

---
*PR created automatically by Jules for task [17464717387222889925](https://jules.google.com/task/17464717387222889925) started by @sl4m3*