### PR TITLE
🎨 Palette: Fix VS Code concurrent loading states clearing errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - VS Code Concurrent Loading States
 **Learning:** Overlapping background operations (like file saves and chat responses) can prematurely clear loading indicators if a simple boolean flag is used for state tracking. This causes screen readers to announce incorrect idle states while work is still ongoing.
 **Action:** Always use a reference counter (`busyCount`) instead of a boolean for shared UI loading states that map to concurrent async operations.
+## 2026-04-19 - VS Code Persistent Error States
+**Learning:** Persistent error states in VS Code status bars should not be implicitly cleared by concurrent async completion handlers. When overlapping background tasks share UI loading indicators, decoupling the error boolean from the loading counter is necessary to ensure screen readers do not incorrectly announce error resolution when background tasks complete.
+**Action:** Always decouple persistent error state booleans from async reference counters, and require explicit user interaction (e.g. clicking the status bar) to dismiss the error.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -25,46 +25,47 @@ export function activate(context: vscode.ExtensionContext) {
     statusBarItem.command = showOutputCommandId;
 
     let busyCount = 0;
+    let isError = false;
 
-    const setError = (hasError: boolean) => {
-        if (hasError) {
+    const updateStatusBar = () => {
+        if (isError) {
             statusBarItem.text = '$(error) LedgerMind';
             statusBarItem.tooltip = 'LedgerMind: Sync Error (Click to view logs)';
             statusBarItem.accessibilityInformation = { label: 'LedgerMind Sync Error, click to view logs', role: 'button' };
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        } else if (busyCount > 0) {
+            statusBarItem.backgroundColor = undefined;
+            statusBarItem.text = '$(sync~spin) LedgerMind';
+            statusBarItem.tooltip = 'LedgerMind: Syncing Context... (Click to view logs)';
+            statusBarItem.accessibilityInformation = { label: 'LedgerMind Syncing Context, click to view logs', role: 'button' };
         } else {
             statusBarItem.backgroundColor = undefined;
-            if (busyCount > 0) {
-                statusBarItem.text = '$(sync~spin) LedgerMind';
-                statusBarItem.tooltip = 'LedgerMind: Syncing Context... (Click to view logs)';
-                statusBarItem.accessibilityInformation = { label: 'LedgerMind Syncing Context, click to view logs', role: 'button' };
-            } else {
-                statusBarItem.text = '$(database) LedgerMind';
-                statusBarItem.tooltip = 'LedgerMind Dual-Hook Bridge Active (Click to view logs)';
-                statusBarItem.accessibilityInformation = { label: 'LedgerMind Dual-Hook Bridge Active, click to view logs', role: 'button' };
-            }
+            statusBarItem.text = '$(database) LedgerMind';
+            statusBarItem.tooltip = 'LedgerMind Dual-Hook Bridge Active (Click to view logs)';
+            statusBarItem.accessibilityInformation = { label: 'LedgerMind Dual-Hook Bridge Active, click to view logs', role: 'button' };
         }
+    };
+
+    const setError = (hasError: boolean) => {
+        isError = hasError;
+        updateStatusBar();
     };
 
     const setBusy = (busy: boolean) => {
         if (busy) {
             busyCount++;
-            if (busyCount === 1) {
-                setError(false);
-            }
         } else {
             if (busyCount > 0) {
                 busyCount--;
-                if (busyCount === 0) {
-                    setError(false);
-                }
             }
         }
+        updateStatusBar();
     };
 
     context.subscriptions.push(vscode.commands.registerCommand(showOutputCommandId, () => {
         outputChannel.show();
-        setError(false); // Clear error state when logs are opened
+        isError = false; // Clear error state when logs are opened
+        updateStatusBar();
     }));
 
     // ==========================================


### PR DESCRIPTION
💡 What: Made VS Code status bar error state persistent and decoupled from concurrent async loading indicators.
🎯 Why: Overlapping background tasks would prematurely clear persistent error indicators because setBusy implicitly reset them.
♿ Accessibility: Ensures screen readers do not incorrectly announce error resolution when background tasks complete.
📸 Before/After: Visual error state now persists until user explicitely clicks the status bar to view logs.

---
*PR created automatically by Jules for task [22418213829173230](https://jules.google.com/task/22418213829173230) started by @sl4m3*