### PR TITLE
🎨 Palette: Improve accessibility of background tasks during error states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-04-16 - Accessible Error State Management
 **Learning:** Background process errors (like file watcher JSON parsing) need accessible visual cues via the status bar, and users need an interactive path to dismiss these error states (e.g. by clicking to open logs).
 **Action:** Always wrap background processes with accessible error state triggers (`setError(true)`) and ensure the associated UI element's command can clear the error state.
+
+## 2024-04-22 - Visual representation of background tasks in error states
+**Learning:** Users and screen readers lose visibility of active background synchronization if an unacknowledged persistent error state entirely overrides the status bar.
+**Action:** When overlapping states occur, dynamically combine icons and accessibility labels (e.g., error and active sync) to ensure both critical conditions remain visible.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -29,9 +29,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     const updateStatusBar = () => {
         if (isError) {
-            statusBarItem.text = '$(error) LedgerMind';
-            statusBarItem.tooltip = 'LedgerMind: Sync Error (Click to view logs)';
-            statusBarItem.accessibilityInformation = { label: 'LedgerMind Sync Error, click to view logs', role: 'button' };
+            statusBarItem.text = busyCount > 0 ? '$(sync~spin) $(error) LedgerMind' : '$(error) LedgerMind';
+            statusBarItem.tooltip = busyCount > 0 ? 'LedgerMind: Sync Error (Syncing...) (Click to view logs)' : 'LedgerMind: Sync Error (Click to view logs)';
+            statusBarItem.accessibilityInformation = { label: busyCount > 0 ? 'LedgerMind Sync Error and Syncing Context, click to view logs' : 'LedgerMind Sync Error, click to view logs', role: 'button' };
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
         } else if (busyCount > 0) {
             statusBarItem.backgroundColor = undefined;


### PR DESCRIPTION
💡 What: Made the status bar show the sync spinner even when an error state is active.
🎯 Why: Users and screen readers could not tell if background synchronization was still occurring if an unacknowledged error was present.
♿ Accessibility: Added dynamic aria-labels to the error state indicating both error and active sync.

---
*PR created automatically by Jules for task [1945455559221176234](https://jules.google.com/task/1945455559221176234) started by @sl4m3*