### PR TITLE
🎨 Palette: Improve JSON parse error visibility

### DIFF
--- a/src/ledgermind/server/cli.py
+++ b/src/ledgermind/server/cli.py
@@ -884,7 +884,8 @@ def sync_transcript_history(bridge, transcript_path: str) -> set:
             if isinstance(ctx, str):
                 try:
                     ctx = json.loads(ctx)
-                except:
+                except json.JSONDecodeError as e:
+                    global_console.print(f"[yellow]Warning: Failed to parse context JSON: {e}[/yellow]")
                     ctx = {}
             if isinstance(ctx, dict) and "transcript_id" in ctx:
                 processed_ids.add(ctx["transcript_id"])


### PR DESCRIPTION
💡 What: Replaced a bare `except:` block in the CLI transcript sync logic with an explicit `except json.JSONDecodeError as e:` and added a formatted, color-coded `rich` console warning.
🎯 Why: Previously, invalid JSON lines in the sync transcript were silently ignored, returning an empty dictionary. This invisible failure obscured corrupted data and caused debugging frustration for users/developers. The explicit warning provides immediate, actionable feedback.
📸 Before/After:
Before: Silent failure.
After: Outputs `[yellow]Warning: Failed to parse context JSON: [error details][/yellow]` to the console.
♿ Accessibility: Uses the existing color-coded (`yellow`) and semantic ("Warning") conventions of the CLI's rich formatting to ensure the error state is clear.

---
*PR created automatically by Jules for task [12643695223778339595](https://jules.google.com/task/12643695223778339595) started by @sl4m3*