### PR TITLE
🎨 Palette: Surface background CLI errors with actionable toast notifications

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-04-22 - Visual representation of background tasks in error states
 **Learning:** Users and screen readers lose visibility of active background synchronization if an unacknowledged persistent error state entirely overrides the status bar.
 **Action:** When overlapping states occur, dynamically combine icons and accessibility labels (e.g., error and active sync) to ensure both critical conditions remain visible.
+## 2024-05-24 - Actionable error states for missing background dependencies
+**Learning:** When background operations fail due to missing external CLI dependencies (e.g., `ENOENT` on `execFile`), surfacing the failure with just a silent red status bar is inaccessible and leaves users confused.
+**Action:** Surface such critical environment failures with a one-time actionable toast notification (`vscode.window.showErrorMessage`) so users know exactly what went wrong and how to fix their environment, while still allowing them to clear the error state.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,8 +1,0 @@
-🎯 **What**
-Fixed a medium severity security risk in `EpisodicStore.query` where `.format()` was being used to insert `where_clause` and `direction` into a SQL query template string.
-
-⚠️ **Risk**
-Using string formatting mechanisms like `.format()` or f-strings for SQL structure exposes the code to SQL Structural Injection. Even if the variables (like `ASC`/`DESC`) are currently heavily sanitized or generated statically internally, using `.format()` creates a dangerous anti-pattern that can be exploited in the future if input validation logic is modified or bypassed.
-
-🛡️ **Solution**
-Refactored the SQL query building to use explicit static string concatenation along with strict `if/else` logic specifically for identifiers like the `ASC`/`DESC` direction parameter. This makes the query completely immune to structural manipulation from dynamic data and complies with the LedgerMind secure coding standards for SQL template generation.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -51,6 +51,23 @@ export function activate(context: vscode.ExtensionContext) {
         updateStatusBar();
     };
 
+    let hasShownMissingCliWarning = false;
+
+    const handleCliError = (err: any, contextMsg: string) => {
+        outputChannel.appendLine(`LedgerMind ${contextMsg} Error: ${err.message}`);
+        setError(true);
+
+        if (err && (err.code === 'ENOENT' || err.message?.includes('ENOENT')) && !hasShownMissingCliWarning) {
+            hasShownMissingCliWarning = true;
+            vscode.window.showErrorMessage('LedgerMind CLI (ledgermind-mcp) not found. Please install it to enable background sync.', 'View Logs').then(selection => {
+                if (selection === 'View Logs') {
+                    outputChannel.show();
+                    setError(false);
+                }
+            });
+        }
+    };
+
     const setBusy = (busy: boolean) => {
         if (busy) {
             busyCount++;
@@ -105,8 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
             ], (err) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind Record Error: ${err.message}`);
-                    setError(true);
+                    handleCliError(err, 'Record');
                 } else {
                     outputChannel.appendLine(`✓ Recorded previous interaction: "${interaction.prompt.substring(0, 50)}..."`);
                 }
@@ -130,8 +146,7 @@ export function activate(context: vscode.ExtensionContext) {
             ], (err, stdout) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind Context Sync Error: ${err.message}`);
-                    setError(true);
+                    handleCliError(err, 'Context Sync');
                 } else if (stdout) {
                     const content = `<!-- LEDGERMIND AUTONOMOUS CONTEXT - DO NOT EDIT -->
 <!-- Updated: ${new Date().toISOString()} -->
@@ -143,8 +158,7 @@ ${stdout}`;
                         fs.writeFileSync(shadowFilePath, content, 'utf-8');
                         outputChannel.appendLine(`✓ Updated shadow context: ${path.basename(shadowFilePath)}`);
                     } catch (writeErr) {
-                        outputChannel.appendLine(`LedgerMind Shadow File Error: ${(writeErr as Error).message}`);
-                        setError(true);
+                        handleCliError(writeErr, 'Shadow File');
                     }
                 }
                 resolve();
@@ -279,8 +293,7 @@ ${stdout}`;
                             ], (err) => {
                                 setBusy(false);
                                 if (err) {
-                                    outputChannel.appendLine(`LedgerMind RooCode Record Error: ${err.message}`);
-                                    setError(true);
+                                    handleCliError(err, 'RooCode Record');
                                 } else {
                                     outputChannel.appendLine(`✓ Recorded RooCode/Cline interaction via file watcher`);
                                 }
@@ -291,8 +304,7 @@ ${stdout}`;
                         }
                     }
                 } catch (err) {
-                    outputChannel.appendLine(`LedgerMind File Watcher Error: ${(err as Error).message}`);
-                    setError(true);
+                    handleCliError(err, 'File Watcher');
                 }
             }, 2000); // Debounce 2s
         });
@@ -332,8 +344,7 @@ ${stdout}`;
                         ], (err) => {
                             setBusy(false);
                             if (err) {
-                                outputChannel.appendLine(`LedgerMind Terminal Record Error: ${err.message}`);
-                                setError(true);
+                                handleCliError(err, 'Terminal Record');
                             }
                         });
                     }
@@ -366,8 +377,7 @@ ${stdout}`;
             ], (err) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind File Record Error: ${err.message}`);
-                    setError(true);
+                    handleCliError(err, 'File Record');
                 }
             });
         })


### PR DESCRIPTION
💡 What
Added a one-time actionable toast notification (`vscode.window.showErrorMessage`) that triggers when the LedgerMind CLI (`ledgermind-mcp`) is missing (ENOENT error). Consolidated all `execFile` error handling into a central `handleCliError` function.

🎯 Why
When background operations like file watchers or terminal monitors fail because the CLI isn't installed, the VS Code extension previously just turned the status bar red silently. This was confusing and inaccessible, as users didn't know what caused the error or how to fix it. The toast notification clearly explains the missing dependency and provides a direct path to view the logs and dismiss the error state.

📸 Before/After
Before: The status bar turned red `$(error) LedgerMind` silently with no explanation when the CLI was missing.
After: The status bar turns red, AND a toast notification pops up saying: "LedgerMind CLI (ledgermind-mcp) not found. Please install it to enable background sync." with a "View Logs" button.

♿ Accessibility
Improves accessibility by ensuring that critical environment failures in background tasks proactively alert the user via standard OS/editor notification channels (which are easily read by screen readers), rather than relying solely on a visual color change in a peripheral status bar.

---
*PR created automatically by Jules for task [7613201048102441506](https://jules.google.com/task/7613201048102441506) started by @sl4m3*