### PR TITLE
🎨 Palette: Add actionable toast notification for missing CLI dependencies

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-26 - VS Code Interactive Status Bar Dismissal
 **Learning:** Dismissing a persistent error state from the status bar via the bound command effectively clears the error state visually, but screen readers might not immediately catch the state change unless explicitly decoupled and re-announced or when the state simply clears via explicit action. In our case, clearing error via the output channel explicitly solves this.
 **Action:** Always provide explicit user interactions to dismiss persistent error states.
+
+## 2026-04-26 - Actionable Toasts for Missing Dependencies
+**Learning:** When background operations fail due to missing external CLI dependencies (e.g., ENOENT on execFile), surfacing the failure with a one-time actionable toast notification (`vscode.window.showErrorMessage`) rather than just silently turning the status bar red provides users with exactly how to fix their environment.
+**Action:** Use actionable toast notifications to guide users in resolving missing dependencies.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,12 +1,4 @@
-💡 What
-Optimized the tight core filtering loop within `QueryService.search` to fail fast and avoid redundant dictionary access. Extracted the `confidence` score evaluation before assigning arbitrary JSON context fields, combined the dictionary ID array extraction using direct key access instead of `.get()`.
-
-🎯 Why
-Profiling showed that during RRF ranking iteration over `all_candidates`, parsing the context JSON and redundantly allocating non-essential dictionary variables to `cand` before doing the confidence check introduced unnecessary performance overhead and latency in the search hot path.
-
-📊 Impact
-- Up to **15-20% faster** execution times for large candidate filtering batches.
-- Benchmarks showed reducing overhead from 4.45s to 4.16s when evaluating 500,000 un-cached dictionaries, avoiding unnecessary context map parsing on low-confidence nodes.
-
-🔬 Measurement
-Verify the overall RRF latency using simulated load tests against large batch results, ensuring the fast path continues returning valid structures.
+💡 What: Replaced silent status bar error toggling on `ENOENT` (command not found) errors with an actionable toast notification linking to the installation docs.
+🎯 Why: The previous behavior left users unaware of why the status bar turned red if `ledgermind-mcp` wasn't in their PATH. A one-time toast immediately guides them to a solution.
+📸 Before/After: Before: Silent red status bar. After: Red status bar + Actionable Toast with 'View Installation Docs' button.
+♿ Accessibility: Ensures that background failure modes are explicitly communicated to users, rather than relying solely on visual indicators in the status bar.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -51,6 +51,27 @@ export function activate(context: vscode.ExtensionContext) {
         updateStatusBar();
     };
 
+    let hasShownEnoentToast = false;
+    const handleExecError = (err: Error | null, contextMessage: string) => {
+        if (!err) return;
+
+        outputChannel.appendLine(`${contextMessage}: ${err.message}`);
+        setError(true);
+
+        // Check if error is ENOENT (command not found)
+        if ((err as any).code === 'ENOENT' && !hasShownEnoentToast) {
+            hasShownEnoentToast = true;
+            vscode.window.showErrorMessage(
+                'LedgerMind MCP not found. Please ensure "ledgermind-mcp" is installed and in your PATH.',
+                'View Installation Docs'
+            ).then(selection => {
+                if (selection === 'View Installation Docs') {
+                    vscode.env.openExternal(vscode.Uri.parse('https://github.com/ledgermind/ledgermind#installation'));
+                }
+            });
+        }
+    };
+
     const setBusy = (busy: boolean) => {
         if (busy) {
             busyCount++;
@@ -105,8 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
             ], (err) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind Record Error: ${err.message}`);
-                    setError(true);
+                    handleExecError(err, 'LedgerMind Record Error');
                 } else {
                     outputChannel.appendLine(`✓ Recorded previous interaction: "${interaction.prompt.substring(0, 50)}..."`);
                 }
@@ -130,8 +150,7 @@ export function activate(context: vscode.ExtensionContext) {
             ], (err, stdout) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind Context Sync Error: ${err.message}`);
-                    setError(true);
+                    handleExecError(err, 'LedgerMind Context Sync Error');
                 } else if (stdout) {
                     const content = `<!-- LEDGERMIND AUTONOMOUS CONTEXT - DO NOT EDIT -->
 <!-- Updated: ${new Date().toISOString()} -->
@@ -279,8 +298,7 @@ ${stdout}`;
                             ], (err) => {
                                 setBusy(false);
                                 if (err) {
-                                    outputChannel.appendLine(`LedgerMind RooCode Record Error: ${err.message}`);
-                                    setError(true);
+                                    handleExecError(err, 'LedgerMind RooCode Record Error');
                                 } else {
                                     outputChannel.appendLine(`✓ Recorded RooCode/Cline interaction via file watcher`);
                                 }
@@ -332,8 +350,7 @@ ${stdout}`;
                         ], (err) => {
                             setBusy(false);
                             if (err) {
-                                outputChannel.appendLine(`LedgerMind Terminal Record Error: ${err.message}`);
-                                setError(true);
+                                handleExecError(err, 'LedgerMind Terminal Record Error');
                             }
                         });
                     }
@@ -366,8 +383,7 @@ ${stdout}`;
             ], (err) => {
                 setBusy(false);
                 if (err) {
-                    outputChannel.appendLine(`LedgerMind File Record Error: ${err.message}`);
-                    setError(true);
+                    handleExecError(err, 'LedgerMind File Record Error');
                 }
             });
         })


### PR DESCRIPTION
💡 What: Replaced silent status bar error toggling on `ENOENT` (command not found) errors with an actionable toast notification linking to the installation docs.
🎯 Why: The previous behavior left users unaware of why the status bar turned red if `ledgermind-mcp` wasn't in their PATH. A one-time toast immediately guides them to a solution.
📸 Before/After: Before: Silent red status bar. After: Red status bar + Actionable Toast with 'View Installation Docs' button.
♿ Accessibility: Ensures that background failure modes are explicitly communicated to users, rather than relying solely on visual indicators in the status bar.

---
*PR created automatically by Jules for task [3804356402408973065](https://jules.google.com/task/3804356402408973065) started by @sl4m3*