### PR TITLE
🎨 Palette: Add Actionable Toasts for Background Errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-04-26 - Actionable Toasts for Missing Dependencies
 **Learning:** When background operations fail due to missing external CLI dependencies (e.g., ENOENT on execFile), surfacing the failure with a one-time actionable toast notification (`vscode.window.showErrorMessage`) rather than just silently turning the status bar red provides users with exactly how to fix their environment.
 **Action:** Use actionable toast notifications to guide users in resolving missing dependencies.
+
+## 2024-05-05 - Actionable Toasts for Silent Background Failures
+**Learning:** When background operations fail, silently turning the status bar red is insufficient. Users might miss the error state, making it hard to diagnose issues. Adding a one-time actionable toast (`vscode.window.showErrorMessage`) with a 'View Logs' button guides them directly to the failure reason without spamming notifications on every retry.
+**Action:** Always surface silent background failures with actionable toast notifications that guide users to the logs or resolution steps.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,4 +1,14 @@
-💡 What: Replaced silent status bar error toggling on `ENOENT` (command not found) errors with an actionable toast notification linking to the installation docs.
-🎯 Why: The previous behavior left users unaware of why the status bar turned red if `ledgermind-mcp` wasn't in their PATH. A one-time toast immediately guides them to a solution.
-📸 Before/After: Before: Silent red status bar. After: Red status bar + Actionable Toast with 'View Installation Docs' button.
-♿ Accessibility: Ensures that background failure modes are explicitly communicated to users, rather than relying solely on visual indicators in the status bar.
+🎨 Palette: Add Actionable Toasts for Background Errors
+
+💡 What:
+Added a one-time actionable toast notification with a 'View Logs' button for non-ENOENT background errors in the VS Code extension.
+
+🎯 Why:
+Previously, when background tasks failed, the status bar would silently turn red. Users often miss this visual cue, leading to confusion about why context synchronization isn't working. The toast provides immediate feedback and an actionable path to diagnose the issue via logs.
+
+📸 Before/After:
+Before: Status bar turns red silently. User must notice it and click to view logs.
+After: Status bar turns red, AND a toast appears: "LedgerMind Background Error: [context]" with a "View Logs" button.
+
+♿ Accessibility:
+Improves screen reader awareness of background failures, as standard toasts are automatically announced by assistive technologies, whereas status bar color changes are purely visual.

--- a/src/ledgermind/vscode/src/extension.ts
+++ b/src/ledgermind/vscode/src/extension.ts
@@ -56,17 +56,30 @@ export function activate(context: vscode.ExtensionContext) {
         if (!err) return;
 
         outputChannel.appendLine(`${contextMessage}: ${err.message}`);
+        const wasError = isError;
         setError(true);
 
         // Check if error is ENOENT (command not found)
-        if ((err as any).code === 'ENOENT' && !hasShownEnoentToast) {
-            hasShownEnoentToast = true;
+        if ((err as any).code === 'ENOENT') {
+            if (!hasShownEnoentToast) {
+                hasShownEnoentToast = true;
+                vscode.window.showErrorMessage(
+                    'LedgerMind MCP not found. Please ensure "ledgermind-mcp" is installed and in your PATH.',
+                    'View Installation Docs'
+                ).then(selection => {
+                    if (selection === 'View Installation Docs') {
+                        vscode.env.openExternal(vscode.Uri.parse('https://github.com/ledgermind/ledgermind#installation'));
+                    }
+                });
+            }
+        } else if (!wasError) {
+            // Show actionable toast for other background errors
             vscode.window.showErrorMessage(
-                'LedgerMind MCP not found. Please ensure "ledgermind-mcp" is installed and in your PATH.',
-                'View Installation Docs'
+                `LedgerMind Background Error: ${contextMessage}`,
+                'View Logs'
             ).then(selection => {
-                if (selection === 'View Installation Docs') {
-                    vscode.env.openExternal(vscode.Uri.parse('https://github.com/ledgermind/ledgermind#installation'));
+                if (selection === 'View Logs') {
+                    vscode.commands.executeCommand('ledgermind.showOutput');
                 }
             });
         }


### PR DESCRIPTION
🎨 Palette: Add Actionable Toasts for Background Errors

💡 What:
Added a one-time actionable toast notification with a 'View Logs' button for non-ENOENT background errors in the VS Code extension.

🎯 Why:
Previously, when background tasks failed, the status bar would silently turn red. Users often miss this visual cue, leading to confusion about why context synchronization isn't working. The toast provides immediate feedback and an actionable path to diagnose the issue via logs.

📸 Before/After:
Before: Status bar turns red silently. User must notice it and click to view logs.
After: Status bar turns red, AND a toast appears: "LedgerMind Background Error: [context]" with a "View Logs" button.

♿ Accessibility:
Improves screen reader awareness of background failures, as standard toasts are automatically announced by assistive technologies, whereas status bar color changes are purely visual.

---
*PR created automatically by Jules for task [6303667970098340524](https://jules.google.com/task/6303667970098340524) started by @sl4m3*