### PR TITLE
🎨 Palette: [UX improvement] Replace text input with autocomplete for CLI model selection

### DIFF
--- a/src/ledgermind/server/cli.py
+++ b/src/ledgermind/server/cli.py
@@ -310,7 +310,11 @@ def init_project(path: str):
         )
 
         while True:
-            enrichment_model = questionary.text("Model Name:", default="").ask()
+            enrichment_model = questionary.autocomplete(
+                "Model Name:",
+                choices=["stepfun/step-3.5-flash:free", "minimax/minimax-m2.5:free", "openrouter/free"],
+                default=""
+            ).ask()
 
             if enrichment_model is None:
                 break
@@ -427,8 +431,11 @@ def init_project(path: str):
             global_console.print("Examples: gemini-2.5-flash-lite, gemini-2.0-flash")
 
         while True:
-            enrichment_model = questionary.text(
-                "Model Name (leave empty for default):", default=""
+            choices = ["claude-sonnet-4-6", "claude-haiku-4-5"] if client == "claude" else ["gemini-2.5-flash-lite", "gemini-2.0-flash"]
+            enrichment_model = questionary.autocomplete(
+                "Model Name (leave empty for default):",
+                choices=choices,
+                default=""
             ).ask()
 
             if enrichment_model is None:
@@ -547,8 +554,10 @@ def init_project(path: str):
 
         # Model selection with validation
         while True:
-            aistudio_model = questionary.text(
-                "Model Name (for example gemma-3-27b-it):", default=""
+            aistudio_model = questionary.autocomplete(
+                "Model Name (for example gemma-3-27b-it):",
+                choices=["gemma-3-27b-it", "gemma-2-9b-it", "gemini-2.5-flash"],
+                default=""
             ).ask()
 
             if aistudio_model is None:

--- a/tests/server/test_cli_smoke.py
+++ b/tests/server/test_cli_smoke.py
@@ -50,8 +50,8 @@ def test_cli_init_and_check(tmp_path):
         # Mock answers: Project Path, Memory Path
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
         # Mock answers: Language
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
         # Mock answers: Embedder, Client, Provider, Mode
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         # Mock confirm (for OpenRouter/AI Studio retry)
@@ -75,8 +75,8 @@ def test_cli_stats(tmp_path):
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -93,8 +93,8 @@ def test_cli_verbose_logging(tmp_path):
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -113,8 +113,8 @@ def test_cli_settings(tmp_path):
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "rich"]
         run_cli(["init", "--path", memory_path])
     

--- a/tests/server/test_cli_smoke.py
+++ b/tests/server/test_cli_smoke.py
@@ -50,7 +50,7 @@ def test_cli_init_and_check(tmp_path):
         # Mock answers: Project Path, Memory Path
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
         # Mock answers: Language
-        mock_autocomplete.return_value.ask.side_effect = ["russian"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
         # Mock answers: Embedder, Client, Provider, Mode
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         # Mock confirm (for OpenRouter/AI Studio retry)
@@ -69,9 +69,11 @@ def test_cli_init_and_check(tmp_path):
 
 def test_cli_stats(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
-    with patch('ledgermind.server.cli.questionary.text') as mock_text, \
+    with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
-        mock_text.return_value.ask.side_effect = [str(tmp_path), memory_path, "russian"]
+        mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -83,9 +85,11 @@ def test_cli_stats(tmp_path):
 
 def test_cli_verbose_logging(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
-    with patch('ledgermind.server.cli.questionary.text') as mock_text, \
+    with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
-        mock_text.return_value.ask.side_effect = [str(tmp_path), memory_path, "russian"]
+        mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -99,9 +103,11 @@ def test_cli_verbose_logging(tmp_path):
 def test_cli_settings(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
     # Initialize first
-    with patch('ledgermind.server.cli.questionary.text') as mock_text, \
+    with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
-        mock_text.return_value.ask.side_effect = [str(tmp_path), memory_path, "russian"]
+        mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "rich"]
         run_cli(["init", "--path", memory_path])
     

--- a/tests/server/test_cli_smoke.py
+++ b/tests/server/test_cli_smoke.py
@@ -46,12 +46,14 @@ def test_cli_init_and_check(tmp_path):
          patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.select') as mock_select, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
-         patch('ledgermind.server.cli.questionary.confirm') as mock_confirm:
+         patch('ledgermind.server.cli.questionary.confirm') as mock_confirm, \
+         patch('ledgermind.server.cli.questionary.password') as mock_password:
         # Mock answers: Project Path, Memory Path
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
         # Mock answers: Language
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy"]
+        mock_password.return_value.ask.side_effect = ["dummy"]
         # Mock answers: Embedder, Client, Provider, Mode
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         # Mock confirm (for OpenRouter/AI Studio retry)
@@ -73,10 +75,12 @@ def test_cli_stats(tmp_path):
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
          patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
-         patch('ledgermind.server.cli.questionary.select') as mock_select:
+         patch('ledgermind.server.cli.questionary.select') as mock_select, \
+         patch('ledgermind.server.cli.questionary.password') as mock_password:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy"]
+        mock_password.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -91,10 +95,12 @@ def test_cli_verbose_logging(tmp_path):
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
          patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
-         patch('ledgermind.server.cli.questionary.select') as mock_select:
+         patch('ledgermind.server.cli.questionary.select') as mock_select, \
+         patch('ledgermind.server.cli.questionary.password') as mock_password:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy"]
+        mock_password.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -111,10 +117,12 @@ def test_cli_settings(tmp_path):
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
          patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
-         patch('ledgermind.server.cli.questionary.select') as mock_select:
+         patch('ledgermind.server.cli.questionary.select') as mock_select, \
+         patch('ledgermind.server.cli.questionary.password') as mock_password:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", ""]
-        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy"]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", "", "", "", "", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy", "dummy"]
+        mock_password.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "rich"]
         run_cli(["init", "--path", memory_path])
     

--- a/tests/server/test_cli_smoke.py
+++ b/tests/server/test_cli_smoke.py
@@ -50,7 +50,8 @@ def test_cli_init_and_check(tmp_path):
         # Mock answers: Project Path, Memory Path
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
         # Mock answers: Language
-        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy"]
         # Mock answers: Embedder, Client, Provider, Mode
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         # Mock confirm (for OpenRouter/AI Studio retry)
@@ -70,10 +71,12 @@ def test_cli_init_and_check(tmp_path):
 def test_cli_stats(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -86,10 +89,12 @@ def test_cli_stats(tmp_path):
 def test_cli_verbose_logging(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "optimal"]
         run_cli(["init", "--path", memory_path])
     
@@ -104,10 +109,12 @@ def test_cli_settings(tmp_path):
     memory_path = str(tmp_path / "ledgermind")
     # Initialize first
     with patch('ledgermind.server.cli.questionary.path') as mock_path, \
+         patch('ledgermind.server.cli.questionary.text') as mock_text, \
          patch('ledgermind.server.cli.questionary.autocomplete') as mock_autocomplete, \
          patch('ledgermind.server.cli.questionary.select') as mock_select:
         mock_path.return_value.ask.side_effect = [str(tmp_path), memory_path]
-        mock_autocomplete.return_value.ask.side_effect = ["russian", ""]
+        mock_autocomplete.return_value.ask.side_effect = ["russian", "", "", ""]
+        mock_text.return_value.ask.side_effect = ["dummy"]
         mock_select.return_value.ask.side_effect = ["jina-v5-4bit", "none", "cli", "rich"]
         run_cli(["init", "--path", memory_path])
     


### PR DESCRIPTION
💡 What: Upgraded model selection prompts in the initialization CLI flow from free-text inputs (`questionary.text`) to auto-completing dropdowns (`questionary.autocomplete`).
🎯 Why: Prevents user typos and provides clear, immediate suggestions for popular/supported models across different providers (OpenRouter, Claude/Gemini, AI Studio) without needing to memorize exact model strings.
📸 Before/After: Before, users had to manually type "stepfun/step-3.5-flash:free". After, they can start typing and hit TAB to complete from a curated list.
♿ Accessibility: Tab-completion significantly reduces cognitive load and manual keystrokes, improving overall keyboard accessibility of the setup process.

---
*PR created automatically by Jules for task [1058705665500673370](https://jules.google.com/task/1058705665500673370) started by @sl4m3*