### PR TITLE
⚡ Bolt: Optimize conflict detection using list_active_conflicts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,6 @@
 ## 2024-05-26 - Generate Cache Keys Efficiently
 **Learning:** Generating stable keys by sorting IDs using an inline `if/else` conditional `(s1, s2) if s1 < s2 else (s2, s1)` is significantly more efficient than `tuple(sorted([s1, s2]))` for pairwise comparison caches in tight loops.
 **Action:** Replace `tuple(sorted(...))` with inline conditional sorting for small fixed-size tuple cache key generation.
+## 2026-05-17 - Optimize Conflict Detection
+**Learning:** Using `list_all()` and filtering `active` statuses in Python iterates over all documents, creating massive overhead for conflict detection.
+**Action:** Use the SQL-optimized `list_active_conflicts()` method, which delegates filtering to SQLite and returns only the matching `fid`s directly.

--- a/src/ledgermind/core/reasoning/conflict.py
+++ b/src/ledgermind/core/reasoning/conflict.py
@@ -1,7 +1,5 @@
 from typing import List, Optional, Any
-import os
 from ledgermind.core.core.schemas import MemoryEvent, KIND_DECISION, KIND_INTERVENTION, ResolutionIntent
-from ledgermind.core.stores.semantic_store.loader import MemoryLoader
 
 class ConflictEngine:
     """
@@ -35,7 +33,8 @@ class ConflictEngine:
         return ResolutionIntent(resolution_type="record", rationale="First entry for target")
 
     def _get_target(self, event: MemoryEvent) -> Optional[str]:
-        if not event.context: return None
+        if not event.context:
+            return None
         target = None
         if hasattr(event.context, "target"):
             target = event.context.target
@@ -44,7 +43,8 @@ class ConflictEngine:
         return target
 
     def _get_namespace(self, event: MemoryEvent) -> str:
-        if not event.context: return "default"
+        if not event.context:
+            return "default"
         if hasattr(event.context, "namespace"):
             return getattr(event.context, "namespace") or "default"
         if isinstance(event.context, dict):
@@ -53,14 +53,13 @@ class ConflictEngine:
 
     def get_conflict_files(self, event: MemoryEvent, namespace: Optional[str] = None) -> List[str]:
         new_target = self._get_target(event)
-        if not new_target: return []
+        if not new_target:
+            return []
 
         if self.meta:
             ns = namespace or self._get_namespace(event)
-            # Find all active decisions for the same target using standard list_all
-            metas = self.meta.list_all(target=new_target, namespace=ns)
-            fids = [m['fid'] for m in metas if m.get('status') == 'active']
-            return fids
+            # Find all active decisions for the same target using SQL-optimized method
+            return self.meta.list_active_conflicts(target=new_target, namespace=ns)
 
         return []
 


### PR DESCRIPTION
💡 What: Replaced `self.meta.list_all` and Python-side filtering with `self.meta.list_active_conflicts` in `ConflictEngine.get_conflict_files`.
🎯 Why: `list_all` fetches all metadata records (which can be huge) and then filters them in Python to find active decisions. `list_active_conflicts` pushes the filtering down to the SQLite database, returning only the needed FIDs directly. This eliminates the overhead of instantiating unnecessary Python dictionaries.
📊 Impact: Eliminates dictionary instantiation overhead for all non-active metadata records during conflict detection, significantly improving intent analysis performance.
🔬 Measurement: Run conflict detection tests/benchmarks on a large semantic store to observe reduced memory usage and faster execution times for `analyze_intent`.

---
*PR created automatically by Jules for task [15177056353756406217](https://jules.google.com/task/15177056353756406217) started by @sl4m3*